### PR TITLE
Prepratory setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 **.Rproj.user*
 **.Rproj
 **.Rhistory
+
+# vscode
+.vscode/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,7 +15,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/tanmaysharma19/pymleda/issues.
+Report bugs at https://github.com/UBC-MDS/pymleda/issues.
 
 If you are reporting a bug, please include:
 
@@ -45,7 +45,7 @@ articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/tanmaysharma19/pymleda/issues.
+The best way to send feedback is to file an issue at https://github.com/UBC-MDS/pymleda/issues.
 
 If you are proposing a feature:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ The official documentation is hosted on Read the Docs: https://pymleda.readthedo
 
 ## Contributors
 
+### Development Leads
+
+- Saule Atymtayeva
+- Sang Yoon Lee
+- Yazan Saleh
+- Tanmay Sharma
+
 We welcome and recognize all contributions. You can see a list of current contributors in the [contributors tab](https://github.com/UBC-MDS/pymleda/graphs/contributors).
 
 ### Credits

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pymleda 
 
-![](https://github.com/tanmaysharma19/pymleda/workflows/build/badge.svg) [![codecov](https://codecov.io/gh/tanmaysharma19/pymleda/branch/main/graph/badge.svg)](https://codecov.io/gh/tanmaysharma19/pymleda) ![Release](https://github.com/tanmaysharma19/pymleda/workflows/Release/badge.svg) [![Documentation Status](https://readthedocs.org/projects/pymleda/badge/?version=latest)](https://pymleda.readthedocs.io/en/latest/?badge=latest)
+![](https://github.com/UBC-MDS/pymleda/workflows/build/badge.svg) [![codecov](https://codecov.io/gh/UBC-MDS/pymleda/branch/main/graph/badge.svg)](https://codecov.io/gh/UBC-MDS/pymleda) ![Release](https://github.com/UBC-MDS/pymleda/workflows/Release/badge.svg) [![Documentation Status](https://readthedocs.org/projects/pymleda/badge/?version=latest)](https://pymleda.readthedocs.io/en/latest/?badge=latest)
 
 Python package that helps with preliminary eda for supervised machine learning tasks.
 
@@ -28,7 +28,7 @@ The official documentation is hosted on Read the Docs: https://pymleda.readthedo
 
 ## Contributors
 
-We welcome and recognize all contributions. You can see a list of current contributors in the [contributors tab](https://github.com/tanmaysharma19/pymleda/graphs/contributors).
+We welcome and recognize all contributions. You can see a list of current contributors in the [contributors tab](https://github.com/UBC-MDS/pymleda/graphs/contributors).
 
 ### Credits
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,13 +32,13 @@ You can either clone the public repository:
 
 .. code-block:: console
 
-    $ git clone git://github.com/tanmaysharma19/pymleda
+    $ git clone git://github.com/UBC-MDS/pymleda
 
 Or download the `tarball`_:
 
 .. code-block:: console
 
-    $ curl  -OL https://github.com/tanmaysharma19/pymleda/tarball/main
+    $ curl  -OL https://github.com/UBC-MDS/pymleda/tarball/main
 
 Once you have a copy of the source, you can install it. The method of installation will depend on the packaging library being used.
 
@@ -55,5 +55,5 @@ If `poetry` is being used (poetry.lock and pyproject.toml files are present), in
     $ poetry install
 
 
-.. _Github repo: https://github.com/tanmaysharma19/pymleda
-.. _tarball: https://github.com/tanmaysharma19/pymleda/tarball/master
+.. _Github repo: https://github.com/UBC-MDS/pymleda
+.. _tarball: https://github.com/UBC-MDS/pymleda/tarball/master


### PR DESCRIPTION
- Add contributor names to `README.md`. Milestone1 instructions to use `CONTRIBUTING.md` as opposed to `README.md` are out of date per tiff (Closes #4).
- Review `CONDUCT.md`. No changes were necessary (Closes #5 ).
- Fix links in various documents to point to https://github.com/UBC-MDS/pymleda as opposed to https://github.com/personal-repo/pymleda